### PR TITLE
Workaround linux build failing because gprofng finds Java SDK (#6)

### DIFF
--- a/Formula/musl-cross.rb
+++ b/Formula/musl-cross.rb
@@ -130,9 +130,9 @@ class MuslCross < Formula
         fakejdk_bin.mkpath
         %w[javac java].each do |b|
           (fakejdk_bin/b).write <<~EOS
-          #!/bin/sh
-          exit 1
-        EOS
+            #!/bin/sh
+            exit 1
+          EOS
           chmod "+x", fakejdk_bin/b
         end
         ENV.prepend_path "PATH", fakejdk_bin

--- a/Formula/musl-cross.rb
+++ b/Formula/musl-cross.rb
@@ -121,6 +121,23 @@ class MuslCross < Formula
       make = Formula["make"].opt_bin/"gmake"
     else
       make = "make"
+
+      # Linux build fails because gprofng finds Java SDK
+      # https://github.com/jthat/homebrew-musl-cross/issues/6
+      begin
+        # Cause binutils gprofng to find a fake jdk, and thus disable Java profiling support
+        fakejdk_bin = buildpath/"fakejdk/bin"
+        fakejdk_bin.mkpath
+        %w[javac java].each do |b|
+          (fakejdk_bin/b).write <<~EOS
+          #!/bin/sh
+          exit 1
+        EOS
+          chmod "+x", fakejdk_bin/b
+        end
+        ENV.prepend_path "PATH", fakejdk_bin
+      end
+
     end
     targets.each do |target|
       system make, "install", "TARGET=#{target}"


### PR DESCRIPTION
Cause binutils gprofng to find a fake jdk, and thus disable Java profiling support.